### PR TITLE
Publish .asf.yaml on asf-site branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           retention-days: 14
       - name: 👷🏻 Copy .asf.yaml to /dist/
         if: ${{ github.event_name == 'push' }}
-        run: | 
+        run: |
           # The asf.yaml file must be in the branch from which the files are published.
           # Otherwise, ASF publising tools cannot detect it.
           cp .asf.yaml ./dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,12 @@ jobs:
           path: './dist'
           if-no-files-found: error
           retention-days: 14
+      - name: 👷🏻 Copy .asf.yaml to /dist/
+        if: ${{ github.event_name == 'push' }}
+        run: | 
+          # The asf.yaml file must be in the branch from which the files are published. 
+          # Otherwise, ASF publising tools cannot detect it.
+          cp .asf.yaml ./dist/
       - name: 🚀 Deploy website on asf-site branch
         uses: apache/airflow-JamesIves-github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: 👷🏻 Copy .asf.yaml to /dist/
         if: ${{ github.event_name == 'push' }}
         run: | 
-          # The asf.yaml file must be in the branch from which the files are published. 
+          # The asf.yaml file must be in the branch from which the files are published.
           # Otherwise, ASF publising tools cannot detect it.
           cp .asf.yaml ./dist/
       - name: 🚀 Deploy website on asf-site branch


### PR DESCRIPTION
Hello

ASF Publishing tools can't detect his file.  According to [asf infra report](https://infra-reports.apache.org/site-source/), we must have this file on the `asf-site` branch.

> This page will also tell you which  branch you are currently publishing as your web site. This is (should  be) the branch that you must add a .asf.yaml meta file to.

For more, see: https://lists.apache.org/thread.html/raf30ca1c77b81bc8c535c53b7aff38e1ff3c755ce84f4a40a6d8ad53%40%3Cusers.infra.apache.org%3E

Best regards,
Kamil Breguła